### PR TITLE
Fix db config when using Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     depends_on: ["database"]
     ports: ["8080:8080"]
     volumes:
-    - "./resources/config/config.docker.edn:/data/conf/config.edn"
+    - "./resources/config/config.docker.edn:/data/resources/config/config.edn"
   database:
     image: postgres:alpine
     restart: unless-stopped

--- a/resources/config/config.docker.edn
+++ b/resources/config/config.docker.edn
@@ -1,6 +1,6 @@
 {:http {:port 8080}
  :postgresql {:dbtype "postgres"
-              :host "localhost"
+              :host "database"
               :dbname "boodle"
               :username "admin"
               :password "admin"}}


### PR DESCRIPTION
# Problem

When starting up using the instructions for Docker, the app fails to connect to the database. It shows the following log:

```
app_1       | [worker-2] INFO com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Starting...
app_1       | [worker-2] ERROR com.zaxxer.hikari.pool.HikariPool - HikariPool-1 - Exception during pool initialization.
app_1       | org.postgresql.util.PSQLException: Connection to localhost:5432 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.
```

# Solution

There are two issues fixed:

1. The path for the Docker volume config file did not match the path for the config that is actually loaded
2. `config.docker.edn` postgresql host should be the name of the database container